### PR TITLE
docs: add MowlCoder (Gleb Alfutin) to the jury list

### DIFF
--- a/pages/2024.md
+++ b/pages/2024.md
@@ -115,6 +115,10 @@ These programmers are in the jury (in alphabetic order of their GitHub nicknames
 [@l3r8yJ](https://github.com/l3r8yJ)
 {: .jury}
 
+![Gleb Alfutin](https://github.com/MowlCoder.png)
+[@MowlCoder](https://github.com/MowlCoder)
+{: .jury}
+
 ![Natalia Pozhidaeva](https://github.com/pnatashap.png)
 [@pnatashap](https://github.com/pnatashap)
 {: .jury}


### PR DESCRIPTION
Add MowlCoder (Gleb Alfutin) to the jury list.
