### PR TITLE
docs(#mowl): Add MowlCoder to jury members in 2025.md

### DIFF
--- a/pages/2025.md
+++ b/pages/2025.md
@@ -130,6 +130,10 @@ The sum of all marks constitute the final mark of a project.
 [@EpicStep](https://github.com/EpicStep)
 {: .jury}
 
+![Gleb Alfutin](https://github.com/MowlCoder.png)
+[@MowlCoder](https://github.com/MowlCoder)
+{: .jury}
+
 We are still forming the jury.
 If you are interested in joining, please [email us](mailto:jury@kaicode.org).
 {: .firebrick}


### PR DESCRIPTION
Adds Gleb Alfutin (@MowlCoder) to the 2025 jury list in `pages/2025.md`.
