### PR TITLE
Add Konstantin Gvencadze to jury members

### DIFF
--- a/pages/2025.md
+++ b/pages/2025.md
@@ -134,6 +134,10 @@ The sum of all marks constitute the final mark of a project.
 [@MowlCoder](https://github.com/MowlCoder)
 {: .jury}
 
+![Konstantin Gvencadze](https://github.com/gvencadze.png)
+[@gvencadze](https://github.com/gvencadze)
+{: .jury}
+
 We are still forming the jury.
 If you are interested in joining, please [email us](mailto:jury@kaicode.org).
 {: .firebrick}


### PR DESCRIPTION
Adds Konstantin Gvencadze (@gvencadze) to the jury list.
